### PR TITLE
feat: Implement change master password modal and logout redirection

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -26,4 +26,13 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  {
+    files: ['tailwind.config.js', 'postcss.config.cjs'], // Target specific config files
+    languageOptions: {
+      sourceType: 'commonjs', // Specify they are CommonJS
+      globals: {
+        ...globals.node, // Add Node.js globals like module, require, etc.
+      },
+    },
+  }
 ])

--- a/frontend/src/components/AddEntryModal.jsx
+++ b/frontend/src/components/AddEntryModal.jsx
@@ -12,10 +12,10 @@ const AddEntryModal = ({
   showPasswordTooltip,
   setShowPasswordTooltip,
   generatePassword,
-  passwordSettings,
-  setPasswordSettings,
-  showPasswordSettings,
-  setShowPasswordSettings,
+  // passwordSettings, // Removed as per lint error
+  // setPasswordSettings, // Removed as per lint error
+  // showPasswordSettings, // Removed as per lint error
+  setShowPasswordSettings, // This is used to open the settings modal
 }) => {
   const [showPassword, setShowPassword] = useState(false);
   const [isSaving, setIsSaving] = useState(false);

--- a/frontend/src/components/AuthForm.jsx
+++ b/frontend/src/components/AuthForm.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ForgotPasswordModal from './ForgotPasswordModal';
 
-const AuthForm = ({ type, onSubmit }) => {
+const AuthForm = ({ type }) => { // Removed onSubmit
   const [form, setForm] = useState({
     username: '',
     email: '',
@@ -53,7 +53,7 @@ const AuthForm = ({ type, onSubmit }) => {
     navigate('/login');
   };
 
-  const handleForgotPassword = async (newPassword) => {
+  const handleForgotPassword = async () => { // Removed newPassword parameter
     // In a real app, this would make an API call to reset the password
     // and clear the vault data on the server side
     console.log('Resetting password and clearing vault data...');

--- a/frontend/src/components/ChangeMasterPasswordModal.jsx
+++ b/frontend/src/components/ChangeMasterPasswordModal.jsx
@@ -1,0 +1,180 @@
+import React, { useState } from 'react';
+import { FaEye, FaEyeSlash, FaCheckCircle, FaTimesCircle } from 'react-icons/fa';
+
+const PasswordRequirement = ({ meets, label }) => (
+  <li className={`flex items-center text-sm ${meets ? 'text-green-500' : 'text-red-500'}`}>
+    {meets ? <FaCheckCircle className="mr-2" /> : <FaTimesCircle className="mr-2" />}
+    {label}
+  </li>
+);
+
+const ChangeMasterPasswordModal = ({ isOpen, onClose }) => {
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showOldPassword, setShowOldPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState('');
+
+  const passwordChecks = [
+    { label: 'At least 8 characters', test: (pw) => pw.length >= 8 },
+    { label: 'At least one uppercase letter', test: (pw) => /[A-Z]/.test(pw) },
+    { label: 'At least one lowercase letter', test: (pw) => /[a-z]/.test(pw) },
+    { label: 'At least one number', test: (pw) => /[0-9]/.test(pw) },
+    { label: 'At least one special character', test: (pw) => /[^A-Za-z0-9]/.test(pw) },
+  ];
+
+  const handleSave = () => {
+    setError('');
+    if (!oldPassword) {
+      setError('Old password is required.');
+      return;
+    }
+    if (!newPassword) {
+      setError('New password is required.');
+      return;
+    }
+    const newPasswordValid = passwordChecks.every(check => check.test(newPassword));
+    if (!newPasswordValid) {
+      setError('New password does not meet all requirements.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError('New passwords do not match.');
+      return;
+    }
+
+    // Simulate password change
+    console.log('Master password change attempt:', { oldPassword, newPassword });
+    alert('Master password change functionality is not yet implemented.'); // Placeholder
+    onClose(); // Close modal on successful (simulated) save
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40" onClick={onClose}>
+      <div
+        className="relative bg-white dark:bg-secondary border border-gold dark:border-gold rounded-2xl shadow-confident p-6 sm:p-8 w-[95vw] max-w-md flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="absolute top-3 right-3 text-xl text-gray-400 hover:text-gold dark:hover:text-gold focus:outline-none"
+          onClick={onClose}
+          type="button"
+          aria-label="Close change master password modal"
+        >
+          <FaTimesCircle />
+        </button>
+        <h2 className="text-xl font-bold text-primary dark:text-gold mb-6 text-center">Change Master Password</h2>
+
+        {error && <p className="text-red-500 bg-red-100 dark:bg-red-900 dark:text-red-300 p-3 rounded-md text-sm mb-4">{error}</p>}
+
+        <form onSubmit={(e) => { e.preventDefault(); handleSave(); }}>
+          <div className="space-y-4">
+            {/* Old Password */}
+            <div className="relative">
+              <label className="block text-sm font-medium text-primary dark:text-gray-300 mb-1" htmlFor="oldPassword">
+                Old Password
+              </label>
+              <input
+                id="oldPassword"
+                type={showOldPassword ? 'text' : 'password'}
+                value={oldPassword}
+                onChange={(e) => setOldPassword(e.target.value)}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-gold focus:border-gold dark:bg-primary dark:text-gray-100"
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowOldPassword(!showOldPassword)}
+                className="absolute inset-y-0 right-0 top-6 pr-3 flex items-center text-gray-500 dark:text-gray-400 hover:text-gold dark:hover:text-gold"
+                aria-label={showOldPassword ? 'Hide old password' : 'Show old password'}
+              >
+                {showOldPassword ? <FaEyeSlash /> : <FaEye />}
+              </button>
+            </div>
+
+            {/* New Password */}
+            <div className="relative">
+              <label className="block text-sm font-medium text-primary dark:text-gray-300 mb-1" htmlFor="newPassword">
+                New Password
+              </label>
+              <input
+                id="newPassword"
+                type={showNewPassword ? 'text' : 'password'}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-gold focus:border-gold dark:bg-primary dark:text-gray-100"
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowNewPassword(!showNewPassword)}
+                className="absolute inset-y-0 right-0 top-6 pr-3 flex items-center text-gray-500 dark:text-gray-400 hover:text-gold dark:hover:text-gold"
+                aria-label={showNewPassword ? 'Hide new password' : 'Show new password'}
+              >
+                {showNewPassword ? <FaEyeSlash /> : <FaEye />}
+              </button>
+            </div>
+
+            {/* Password Requirements */}
+            {newPassword.length > 0 && (
+              <ul className="mt-2 space-y-1 pl-1">
+                {passwordChecks.map((check) => (
+                  <PasswordRequirement
+                    key={check.label}
+                    meets={check.test(newPassword)}
+                    label={check.label}
+                  />
+                ))}
+              </ul>
+            )}
+
+            {/* Confirm New Password */}
+            <div className="relative">
+              <label className="block text-sm font-medium text-primary dark:text-gray-300 mb-1" htmlFor="confirmPassword">
+                Confirm New Password
+              </label>
+              <input
+                id="confirmPassword"
+                type={showConfirmPassword ? 'text' : 'password'}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-gold focus:border-gold dark:bg-primary dark:text-gray-100"
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className="absolute inset-y-0 right-0 top-6 pr-3 flex items-center text-gray-500 dark:text-gray-400 hover:text-gold dark:hover:text-gold"
+                aria-label={showConfirmPassword ? 'Hide confirm password' : 'Show confirm password'}
+              >
+                {showConfirmPassword ? <FaEyeSlash /> : <FaEye />}
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-8 flex justify-end space-x-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-600 hover:bg-gray-200 dark:hover:bg-gray-500 rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-gold hover:bg-yellow-600 dark:hover:bg-yellow-500 rounded-lg transition-colors"
+            >
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ChangeMasterPasswordModal;

--- a/frontend/src/components/ProfileSection.jsx
+++ b/frontend/src/components/ProfileSection.jsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import { FaUserCircle, FaTimes } from 'react-icons/fa';
+import { useNavigate } from 'react-router-dom'; // Import useNavigate
 
-const ProfileSection = ({
+export default function ProfileSection({ // Changed to export default function
   profileOpen,
   setProfileOpen,
-}) => (
+  openChangeMasterPasswordModal, // Add prop to open the modal
+}) {
+  const navigate = useNavigate(); // Initialize navigate
+
+  const handleLogout = () => {
+    // Potentially clear session/token here in a real app
+    navigate('/login');
+  };
+
+  return (
   <>
     {/* Floating Action Button (FAB) */}
     <button
@@ -41,14 +51,17 @@ const ProfileSection = ({
           )} */}
           <button
             className="w-full mt-2 px-4 py-2 rounded-xl bg-silver dark:bg-gold text-primary font-bold shadow-confident border border-silver dark:border-gold hover:bg-gold dark:hover:bg-primary hover:text-gold dark:hover:text-gold transition-colors"
-            // onClick={handleChangePassword}
+            onClick={() => {
+              openChangeMasterPasswordModal();
+              setProfileOpen(false); // Close profile section modal
+            }}
             type="button"
           >
             Change Master Password
           </button>
           <button
             className="w-full mt-2 px-4 py-2 rounded-xl bg-red-500 dark:bg-red-700 text-white font-bold shadow-confident border border-red-500 dark:border-red-400 hover:bg-red-600 dark:hover:bg-primary hover:text-gold dark:hover:text-gold transition-colors"
-            // onClick={handleLogout}
+            onClick={handleLogout}
             type="button"
           >
             Logout
@@ -58,5 +71,5 @@ const ProfileSection = ({
     )}
   </>
 );
-
-export default ProfileSection;
+} // Added closing brace for the function component
+// Removed redundant export default ProfileSection;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -11,6 +11,7 @@ import EditEntryModal from '../components/EditEntryModal';
 import DeleteConfirmModal from '../components/DeleteConfirmModal';
 import CopySuccessModal from '../components/CopySuccessModal';
 import SessionLogoutModal from '../components/SessionLogoutModal';
+import ChangeMasterPasswordModal from '../components/ChangeMasterPasswordModal'; // Import the new modal
 import { useNavigate } from 'react-router-dom';
 
 const MOCK_ENTRIES = [
@@ -51,7 +52,7 @@ const Dashboard = () => {
     notes: '',
     tags: '', // store as comma-separated string for input
   });
-  const [passwordStrength, setPasswordStrength] = useState('');
+  // const [passwordStrength, setPasswordStrength] = useState(''); // Removed unused variable
   const [showPasswordTooltip, setShowPasswordTooltip] = useState(false);
   const [addEntryError, setAddEntryError] = useState('');
 
@@ -129,7 +130,7 @@ const Dashboard = () => {
     
     // Update the password field and strength
     setNewEntry(prev => ({ ...prev, password }));
-    setPasswordStrength(checkStrength(password));
+    // setPasswordStrength(checkStrength(password)); // setPasswordStrength was removed
   };
   // Password generation settings
   const [passwordSettings, setPasswordSettings] = useState({
@@ -165,6 +166,7 @@ const Dashboard = () => {
   const [sessionTimeLeft, setSessionTimeLeft] = useState(SESSION_DURATION);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
   const [logoutCountdown, setLogoutCountdown] = useState(3);
+  const [isChangeMasterPasswordModalOpen, setIsChangeMasterPasswordModalOpen] = useState(false); // State for the new modal
 
   useEffect(() => {
     let timer;
@@ -198,7 +200,7 @@ const Dashboard = () => {
     if (!stored || parseInt(stored, 10) < Date.now()) {
       localStorage.setItem('vault_session_expiry', Date.now() + SESSION_DURATION * 1000);
     }
-  }, []);
+  }, [SESSION_DURATION]); // Added SESSION_DURATION to dependency array
 
   useEffect(() => {
     let logoutTimer;
@@ -242,7 +244,7 @@ const Dashboard = () => {
     },
   ];
 
-  const allPasswordValid = passwordChecks.every(check => check.test(newEntry.password));
+  // const allPasswordValid = passwordChecks.every(check => check.test(newEntry.password)); // Removed unused variable
 
   // Placeholder handlers
   const handleCopy = (entry) => {
@@ -268,28 +270,28 @@ const Dashboard = () => {
   const openAddModal = () => {
     setAddModalOpen(true);
     setNewEntry({ platform: '', username: '', password: '', notes: '', tags: '' });
-    setPasswordStrength('');
+    // setPasswordStrength(''); // Removed as setPasswordStrength is not defined
   };
   const closeAddModal = () => setAddModalOpen(false);
 
   const handleNewEntryChange = e => {
     const { name, value } = e.target;
     setNewEntry(prev => ({ ...prev, [name]: value }));
-    if (name === 'password') setPasswordStrength(checkStrength(value));
+    // if (name === 'password') setPasswordStrength(checkStrength(value)); // setPasswordStrength was removed
   };
 
-  function checkStrength(pw) {
-    if (!pw) return '';
-    let score = 0;
-    if (pw.length >= 8) score++;
-    if (/[A-Z]/.test(pw)) score++;
-    if (/[a-z]/.test(pw)) score++;
-    if (/[0-9]/.test(pw)) score++;
-    if (/[^A-Za-z0-9]/.test(pw)) score++;
-    if (score >= 5) return 'Strong';
-    if (score >= 3) return 'Medium';
-    return 'Weak';
-  }
+  // function checkStrength(pw) { // Removed as it's no longer used
+  //   if (!pw) return '';
+  //   let score = 0;
+  //   if (pw.length >= 8) score++;
+  //   if (/[A-Z]/.test(pw)) score++;
+  //   if (/[a-z]/.test(pw)) score++;
+  //   if (/[0-9]/.test(pw)) score++;
+  //   if (/[^A-Za-z0-9]/.test(pw)) score++;
+  //   if (score >= 5) return 'Strong';
+  //   if (score >= 3) return 'Medium';
+  //   return 'Weak';
+  // }
 
   const handleAddEntry = (e) => {
     e.preventDefault();
@@ -377,7 +379,11 @@ const Dashboard = () => {
       <SummaryStats entries={entries} lastActivity={sessionTimeLeft} />
       <SearchAddBar openAddModal={openAddModal} />
       <VaultEntriesList entries={entries} onCopy={handleCopy} onEdit={handleEdit} onDelete={handleDelete} />
-      <ProfileSection profileOpen={profileOpen} setProfileOpen={setProfileOpen} />
+      <ProfileSection
+        profileOpen={profileOpen}
+        setProfileOpen={setProfileOpen}
+        openChangeMasterPasswordModal={() => setIsChangeMasterPasswordModalOpen(true)} // Pass handler to open modal
+      />
       <AddEntryModal
         addModalOpen={addModalOpen}
         closeAddModal={closeAddModal}
@@ -419,6 +425,10 @@ const Dashboard = () => {
       />
       <CopySuccessModal showCopyModal={showCopyModal} />
       <SessionLogoutModal showLogoutModal={showLogoutModal} logoutCountdown={logoutCountdown} />
+      <ChangeMasterPasswordModal
+        isOpen={isChangeMasterPasswordModalOpen}
+        onClose={() => setIsChangeMasterPasswordModalOpen(false)}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import AuthForm from '../components/AuthForm';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom'; // Removed useNavigate
 
 const Login = () => {
-  const navigate = useNavigate();
+  // const navigate = useNavigate(); // Removed unused variable
   const handleLogin = (data) => {
     console.log('Login data:', data);
   };


### PR DESCRIPTION
- Added a new modal for changing the master password with fields for old, new, and confirm password.
- Implemented password visibility toggles (eye icons) for all password fields in the new modal.
- Added a dynamic password requirement checklist (check/X icons) to the new password field.
- Updated the profile section: 'Change Master Password' button now opens the modal.
- Updated the profile section: 'Logout' button now redirects you to the login page.
- Fixed various linting errors across multiple components.